### PR TITLE
Add simple frontend and enable CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ curl -X POST http://localhost:8000/stop_recording
 curl -X POST http://localhost:8000/transcribe_and_summarize
 ```
 
+## Фронтенд
+
+В каталоге `frontend` есть простой статический интерфейс. Запустите сервер, а затем откройте файл `frontend/index.html` в браузере (или поднимите локальный HTTP-сервер через `python -m http.server` внутри каталога). Интерфейс позволяет запускать и останавливать запись, а также запускать распознавание и отображать транскрипт и резюме.
+
 ## Файлы
 - `recordings/meeting.wav` – исходное аудио
 - `recordings/transcript.txt` – расшифровка речи

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 from rich.console import Console
 
 from .config import config
@@ -12,6 +14,15 @@ from .pipeline import transcribe_and_summarize
 
 console = Console()
 app = FastAPI(title="Zoom Local Secretary")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+app.mount("/recordings", StaticFiles(directory=config.recordings_dir), name="recordings")
+
 recorder = AudioRecorder()
 AUDIO_PATH = config.recordings_dir / "meeting.wav"
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Zoom Local Secretary</title>
+  <style>
+    body { font-family: sans-serif; margin: 2rem; }
+    button { margin-right: 1rem; }
+    pre { background: #f5f5f5; padding: 1rem; }
+  </style>
+</head>
+<body>
+  <h1>Zoom Local Secretary</h1>
+  <div id="controls">
+    <button id="start">Start Recording</button>
+    <button id="stop">Stop Recording</button>
+    <button id="run">Transcribe &amp; Summarize</button>
+  </div>
+  <p id="status"></p>
+  <h2>Transcript</h2>
+  <pre id="transcript"></pre>
+  <h2>Summary</h2>
+  <pre id="summary"></pre>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,0 +1,50 @@
+const statusEl = document.getElementById('status');
+const transcriptEl = document.getElementById('transcript');
+const summaryEl = document.getElementById('summary');
+
+async function post(endpoint) {
+  const res = await fetch(`http://localhost:8000/${endpoint}`, { method: 'POST' });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || res.statusText);
+  }
+  return res.json();
+}
+
+document.getElementById('start').onclick = async () => {
+  statusEl.textContent = 'Starting…';
+  try {
+    const data = await post('start_recording');
+    statusEl.textContent = data.status;
+  } catch (err) {
+    statusEl.textContent = err.message;
+  }
+};
+
+document.getElementById('stop').onclick = async () => {
+  statusEl.textContent = 'Stopping…';
+  try {
+    const data = await post('stop_recording');
+    statusEl.textContent = `${data.status}: ${data.audio_path}`;
+  } catch (err) {
+    statusEl.textContent = err.message;
+  }
+};
+
+document.getElementById('run').onclick = async () => {
+  statusEl.textContent = 'Processing…';
+  transcriptEl.textContent = '';
+  summaryEl.textContent = '';
+  try {
+    const data = await post('transcribe_and_summarize');
+    const [tResp, sResp] = await Promise.all([
+      fetch(`http://localhost:8000/${data.transcript_path}`),
+      fetch(`http://localhost:8000/${data.summary_path}`)
+    ]);
+    transcriptEl.textContent = await tResp.text();
+    summaryEl.textContent = await sResp.text();
+    statusEl.textContent = 'Done';
+  } catch (err) {
+    statusEl.textContent = err.message;
+  }
+};


### PR DESCRIPTION
## Summary
- add static frontend with controls to record, stop and summarize
- enable CORS and serve recordings from FastAPI
- document frontend usage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be947f684c8333b2f0285688ea4391