### PR TITLE
Transcribe recordings to text without LM Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Zoom Local Secretary (WASAPI)
 
-Локальный «секретарь» для Zoom-встреч, который перехватывает системный звук Windows, 
-транскрибирует русскую речь офлайн через [faster-whisper](https://github.com/guillaumekln/faster-whisper)
-и делает краткое резюме встречи через локальный сервер [LM Studio](https://lmstudio.ai/).
+Локальный «секретарь» для Zoom-встреч, который перехватывает системный звук Windows
+и переводит его в текст офлайн через [faster-whisper](https://github.com/guillaumekln/faster-whisper).
 
 ## Установка
 
@@ -25,7 +24,7 @@ uvicorn backend.src.server:app --reload
 |---------|----------|
 | `POST /start_recording` | Начать запись системного аудио. |
 | `POST /stop_recording` | Остановить запись и сохранить `recordings/meeting.wav`. |
-| `POST /transcribe_and_summarize` | Запустить распознавание и резюме. Сохраняет `recordings/transcript.txt` и `recordings/summary.md`. |
+| `POST /transcribe` | Запустить распознавание. Сохраняет `recordings/transcript.txt`. |
 
 Примеры:
 ```bash
@@ -35,15 +34,14 @@ curl -X POST http://localhost:8000/start_recording
 # остановить запись
 curl -X POST http://localhost:8000/stop_recording
 
-# транскрипция и резюме
-curl -X POST http://localhost:8000/transcribe_and_summarize
+# транскрипция
+curl -X POST http://localhost:8000/transcribe
 ```
 
 ## Фронтенд
 
-В каталоге `frontend` есть простой статический интерфейс. Запустите сервер, а затем откройте файл `frontend/index.html` в браузере (или поднимите локальный HTTP-сервер через `python -m http.server` внутри каталога). Интерфейс позволяет запускать и останавливать запись, а также запускать распознавание и отображать транскрипт и резюме.
+В каталоге `frontend` есть простой статический интерфейс. Запустите сервер, а затем откройте файл `frontend/index.html` в браузере (или поднимите локальный HTTP-сервер через `python -m http.server` внутри каталога). Интерфейс позволяет запускать и останавливать запись, а также запускать распознавание и отображать транскрипт.
 
 ## Файлы
 - `recordings/meeting.wav` – исходное аудио
-- `recordings/transcript.txt` – расшифровка речи
-- `recordings/summary.md` – краткое резюме встречи
+- `recordings/transcript.txt` – расшифровка речи с временными метками

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "zoom-local-secretary-wasapi"
 version = "0.1.0"
-description = "Local Zoom secretary capturing system audio, transcribing and summarizing."
+description = "Local Zoom secretary capturing system audio and transcribing it to text."
 authors = [{name = "Zoom Secretary"}]
 requires-python = ">=3.10"
 dependencies = [
@@ -10,7 +10,6 @@ dependencies = [
     "numpy",
     "fastapi",
     "uvicorn",
-    "requests",
     "rich",
     "python-dotenv"
 ]

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -15,8 +15,6 @@ load_dotenv()
 class Config:
     """Application configuration."""
 
-    lm_base_url: str = os.getenv("LM_BASE_URL", "http://localhost:1234/v1")
-    lm_model: str = os.getenv("LM_MODEL", "qwen3-8b-instruct")
     asr_model_size: str = os.getenv("ASR_MODEL_SIZE", "medium")
     asr_device: str = os.getenv("ASR_DEVICE", "cpu")
     asr_compute_type: str = os.getenv("ASR_COMPUTE_TYPE", "int8")

--- a/backend/src/pipeline.py
+++ b/backend/src/pipeline.py
@@ -1,9 +1,8 @@
-"""Transcription and summarization pipeline."""
+"""Transcription pipeline."""
 from __future__ import annotations
 
 from pathlib import Path
 
-import requests
 from faster_whisper import WhisperModel
 from rich.console import Console
 
@@ -12,13 +11,21 @@ from .config import Config
 console = Console()
 
 
-def transcribe_and_summarize(audio_path: Path, cfg: Config) -> tuple[Path, Path]:
-    """Run ASR and summarization on *audio_path*.
+def _format_ts(seconds: float) -> str:
+    """Format seconds as ``HH:MM:SS``."""
+    h = int(seconds // 3600)
+    m = int((seconds % 3600) // 60)
+    s = int(seconds % 60)
+    return f"{h:02d}:{m:02d}:{s:02d}"
 
-    Returns paths to transcript and summary files.
+
+def transcribe(audio_path: Path, cfg: Config) -> Path:
+    """Transcribe *audio_path* and save the result to a text file.
+
+    Each line of the transcript contains the segment index, start and end
+    timestamps, and the recognized text.
     """
     transcript_path = cfg.recordings_dir / "transcript.txt"
-    summary_path = cfg.recordings_dir / "summary.md"
 
     console.log("Loading ASR model")
     model = WhisperModel(
@@ -28,28 +35,13 @@ def transcribe_and_summarize(audio_path: Path, cfg: Config) -> tuple[Path, Path]
     )
 
     segments, _ = model.transcribe(str(audio_path), language=cfg.asr_lang)
-    transcript = " ".join(seg.text.strip() for seg in segments)
-    transcript_path.write_text(transcript, encoding="utf-8")
+    lines: list[str] = []
+    for i, seg in enumerate(segments, 1):
+        start = _format_ts(seg.start)
+        end = _format_ts(seg.end)
+        text = seg.text.strip()
+        lines.append(f"[{i} {start}-{end}] {text}")
+
+    transcript_path.write_text("\n".join(lines), encoding="utf-8")
     console.log(f"Transcript saved to {transcript_path}")
-
-    prompt = "Сделай краткое резюме встречи:\n" + transcript
-    payload = {
-        "model": cfg.lm_model,
-        "messages": [{"role": "user", "content": prompt}],
-    }
-    url = cfg.lm_base_url.rstrip("/") + "/chat/completions"
-
-    console.log(f"Requesting summary from {url}")
-    try:
-        response = requests.post(url, json=payload, timeout=60)
-        response.raise_for_status()
-        data = response.json()
-        summary = data["choices"][0]["message"]["content"].strip()
-    except Exception as exc:  # pragma: no cover - network errors
-        console.log(f"Summarization failed: {exc}")
-        raise
-
-    summary_path.write_text(summary, encoding="utf-8")
-    console.log(f"Summary saved to {summary_path}")
-
-    return transcript_path, summary_path
+    return transcript_path

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -1,8 +1,6 @@
 """FastAPI server for Zoom Local Secretary."""
 from __future__ import annotations
 
-from pathlib import Path
-
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
@@ -10,7 +8,7 @@ from rich.console import Console
 
 from .config import config
 from .recorder import AudioRecorder
-from .pipeline import transcribe_and_summarize
+from .pipeline import transcribe
 
 console = Console()
 app = FastAPI(title="Zoom Local Secretary")
@@ -49,15 +47,12 @@ async def stop_recording() -> dict:
         raise HTTPException(status_code=500, detail=str(exc))
 
 
-@app.post("/transcribe_and_summarize")
+@app.post("/transcribe")
 async def run_pipeline() -> dict:
-    """Transcribe the recording and summarize it."""
+    """Transcribe the recording."""
     try:
-        t_path, s_path = transcribe_and_summarize(AUDIO_PATH, config)
-        return {
-            "transcript_path": str(t_path),
-            "summary_path": str(s_path),
-        }
+        t_path = transcribe(AUDIO_PATH, config)
+        return {"transcript_path": str(t_path)}
     except Exception as exc:
         console.log(f"Pipeline failed: {exc}")
         raise HTTPException(status_code=500, detail=str(exc))

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,13 +14,11 @@
   <div id="controls">
     <button id="start">Start Recording</button>
     <button id="stop">Stop Recording</button>
-    <button id="run">Transcribe &amp; Summarize</button>
+    <button id="run">Transcribe</button>
   </div>
   <p id="status"></p>
   <h2>Transcript</h2>
   <pre id="transcript"></pre>
-  <h2>Summary</h2>
-  <pre id="summary"></pre>
   <script src="script.js"></script>
 </body>
 </html>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,6 +1,5 @@
 const statusEl = document.getElementById('status');
 const transcriptEl = document.getElementById('transcript');
-const summaryEl = document.getElementById('summary');
 
 async function post(endpoint) {
   const res = await fetch(`http://localhost:8000/${endpoint}`, { method: 'POST' });
@@ -34,15 +33,10 @@ document.getElementById('stop').onclick = async () => {
 document.getElementById('run').onclick = async () => {
   statusEl.textContent = 'Processing…';
   transcriptEl.textContent = '';
-  summaryEl.textContent = '';
   try {
-    const data = await post('transcribe_and_summarize');
-    const [tResp, sResp] = await Promise.all([
-      fetch(`http://localhost:8000/${data.transcript_path}`),
-      fetch(`http://localhost:8000/${data.summary_path}`)
-    ]);
+    const data = await post('transcribe');
+    const tResp = await fetch(`http://localhost:8000/${data.transcript_path}`);
     transcriptEl.textContent = await tResp.text();
-    summaryEl.textContent = await sResp.text();
     statusEl.textContent = 'Done';
   } catch (err) {
     statusEl.textContent = err.message;


### PR DESCRIPTION
## Summary
- remove LM Studio summarization pipeline and config
- add timestamped transcription only
- update API, frontend, and docs for transcription-only flow

## Testing
- `python -m py_compile backend/src/config.py backend/src/pipeline.py backend/src/server.py`


------
https://chatgpt.com/codex/tasks/task_e_68bffb7fd9948333aef4dd931e38ffba