### PR TITLE
feat: support file upload transcription

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,7 +14,9 @@
   <div id="controls">
     <button id="start">Start Recording</button>
     <button id="stop">Stop Recording</button>
-    <button id="run">Transcribe</button>
+    <button id="run">Transcribe Recording</button>
+    <input type="file" id="file" accept="audio/*" />
+    <button id="run-file">Transcribe File</button>
   </div>
   <p id="status"></p>
   <h2>Transcript</h2>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,5 +1,6 @@
 const statusEl = document.getElementById('status');
 const transcriptEl = document.getElementById('transcript');
+const fileInput = document.getElementById('file');
 
 async function post(endpoint) {
   const res = await fetch(`http://localhost:8000/${endpoint}`, { method: 'POST' });
@@ -35,6 +36,32 @@ document.getElementById('run').onclick = async () => {
   transcriptEl.textContent = '';
   try {
     const data = await post('transcribe');
+    const tResp = await fetch(`http://localhost:8000/${data.transcript_path}`);
+    transcriptEl.textContent = await tResp.text();
+    statusEl.textContent = 'Done';
+  } catch (err) {
+    statusEl.textContent = err.message;
+  }
+};
+
+document.getElementById('run-file').onclick = async () => {
+  if (!fileInput.files.length) {
+    statusEl.textContent = 'Please select a file';
+    return;
+  }
+  statusEl.textContent = 'Processing…';
+  transcriptEl.textContent = '';
+  const formData = new FormData();
+  formData.append('file', fileInput.files[0]);
+  try {
+    const res = await fetch('http://localhost:8000/transcribe_file', {
+      method: 'POST',
+      body: formData,
+    });
+    if (!res.ok) {
+      throw new Error((await res.text()) || res.statusText);
+    }
+    const data = await res.json();
     const tResp = await fetch(`http://localhost:8000/${data.transcript_path}`);
     transcriptEl.textContent = await tResp.text();
     statusEl.textContent = 'Done';


### PR DESCRIPTION
## Summary
- allow selecting a local audio file for transcription
- add front-end controls and server endpoint to upload and transcribe a file

## Testing
- `python -m py_compile backend/src/server.py`
- `node --check frontend/script.js`


------
https://chatgpt.com/codex/tasks/task_e_68c02eacf1ec83339eccd6f6eff53e54