### PR TITLE
Fix transcribe file endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ uvicorn backend.src.server:app --reload
 | `POST /api/start_recording` | Начать запись системного аудио. |
 | `POST /api/stop_recording` | Остановить запись и сохранить `recordings/meeting.wav`. |
 | `POST /api/transcribe` | Запустить распознавание. Сохраняет `recordings/transcript.txt`. |
+| `POST /api/transcribe_file` | Загрузить аудиофайл и получить его транскрипт. |
 
 Примеры:
 ```bash
@@ -36,6 +37,9 @@ curl -X POST http://localhost:8000/api/stop_recording
 
 # транскрипция
 curl -X POST http://localhost:8000/api/transcribe
+
+# транскрипция загруженного файла
+curl -F "file=@sample.wav" http://localhost:8000/api/transcribe_file
 ```
 
 ## Интерфейс

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -63,13 +63,8 @@ async def run_pipeline() -> dict:
         raise HTTPException(status_code=500, detail=str(exc))
 
 
-# Serve recordings and frontend assets
-app.mount("/recordings", StaticFiles(directory=config.recordings_dir), name="recordings")
-frontend_dir = Path(__file__).resolve().parents[2] / "frontend"
-app.mount("/", StaticFiles(directory=frontend_dir, html=True), name="frontend")
-
-
-@app.post("/transcribe_file")
+# Upload and transcribe arbitrary audio files
+@app.post("/api/transcribe_file")
 async def transcribe_file(file: UploadFile = File(...)) -> dict:
     """Upload an audio file and transcribe it."""
     try:
@@ -81,4 +76,10 @@ async def transcribe_file(file: UploadFile = File(...)) -> dict:
     except Exception as exc:
         console.log(f"File transcription failed: {exc}")
         raise HTTPException(status_code=500, detail=str(exc))
+
+
+# Serve recordings and frontend assets
+app.mount("/recordings", StaticFiles(directory=config.recordings_dir), name="recordings")
+frontend_dir = Path(__file__).resolve().parents[2] / "frontend"
+app.mount("/", StaticFiles(directory=frontend_dir, html=True), name="frontend")
 

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -54,7 +54,7 @@ document.getElementById('run-file').onclick = async () => {
   const formData = new FormData();
   formData.append('file', fileInput.files[0]);
   try {
-    const res = await fetch('/transcribe_file', {
+    const res = await fetch('/api/transcribe_file', {
       method: 'POST',
       body: formData,
     });


### PR DESCRIPTION
## Summary
- expose file transcription under `/api/transcribe_file`
- update frontend fetch call to new API route
- document file transcription API usage

## Testing
- `pytest`
- `python -m py_compile src/server.py`
- `pip install httpx` *(fails: 403 Tunnel connection failed: 403 Forbidden)*
- `python - <<'PY'\nimport sys\nimport importlib\ntry:\n    import src.server as server\n    print('import ok')\nexcept Exception as e:\n    print('import failed:', e)\nPY` *(fails: PortAudio library not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a08963e48333bfec50779a8d8e82