### PR TITLE
Implement cyclic rotation for recordings

### DIFF
--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -11,6 +11,16 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
+def _int_from_env(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
 @dataclass
 class Config:
     """Application configuration."""
@@ -21,6 +31,7 @@ class Config:
     asr_lang: str = os.getenv("ASR_LANG", "ru")
 
     recordings_dir: Path = Path("recordings")
+    max_recordings: int = max(1, _int_from_env("MAX_RECORDINGS", 10))
 
 
 config = Config()

--- a/backend/src/pipeline.py
+++ b/backend/src/pipeline.py
@@ -19,13 +19,16 @@ def _format_ts(seconds: float) -> str:
     return f"{h:02d}:{m:02d}:{s:02d}"
 
 
-def transcribe(audio_path: Path, cfg: Config) -> Path:
+def transcribe(
+    audio_path: Path, cfg: Config, *, transcript_path: Path | None = None
+) -> Path:
     """Transcribe *audio_path* and save the result to a text file.
 
     Each line of the transcript contains the segment index, start and end
     timestamps, and the recognized text.
     """
-    transcript_path = cfg.recordings_dir / "transcript.txt"
+    if transcript_path is None:
+        transcript_path = cfg.recordings_dir / "transcript.txt"
 
     console.log("Loading ASR model")
     model = WhisperModel(

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -1,6 +1,7 @@
 """FastAPI server for Zoom Local Secretary."""
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 
@@ -27,7 +28,84 @@ app.add_middleware(
 )
 
 recorder = AudioRecorder()
-AUDIO_PATH = config.recordings_dir / "meeting.wav"
+
+
+class RecordingManager:
+    """Manage cyclic storage of recorded audio and transcripts."""
+
+    def __init__(self, directory: Path, limit: int, prefix: str = "meeting") -> None:
+        self.directory = directory
+        self.limit = max(1, limit)
+        self.prefix = prefix
+        self.state_file = self.directory / ".state.json"
+        self.directory.mkdir(parents=True, exist_ok=True)
+        self._next_index = 0
+        self._latest_index: int | None = None
+        self._load_state()
+
+    def _load_state(self) -> None:
+        if not self.state_file.exists():
+            return
+        try:
+            data = json.loads(self.state_file.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return
+
+        next_index = data.get("next_index")
+        if isinstance(next_index, int):
+            self._next_index = next_index % self.limit
+
+        latest_index = data.get("latest_index")
+        if isinstance(latest_index, int):
+            self._latest_index = latest_index % self.limit
+
+    def _save_state(self) -> None:
+        data = {"next_index": self._next_index}
+        if self._latest_index is not None:
+            data["latest_index"] = self._latest_index
+        self.state_file.write_text(json.dumps(data), encoding="utf-8")
+
+    def _path_for_index(self, index: int, suffix: str) -> Path:
+        return self.directory / f"{self.prefix}_{index + 1:02d}.{suffix}"
+
+    def prepare_audio_path(self) -> Path:
+        """Return the path for the next recording without updating state."""
+
+        return self._path_for_index(self._next_index, "wav")
+
+    def commit_recording(self) -> Path:
+        """Finalize the latest recording and advance the cyclic index."""
+
+        idx = self._next_index
+        transcript_path = self._path_for_index(idx, "txt")
+        if transcript_path.exists():
+            transcript_path.unlink()
+
+        self._latest_index = idx
+        self._next_index = (idx + 1) % self.limit
+        self._save_state()
+        return self._path_for_index(idx, "wav")
+
+    def latest_audio_path(self) -> Path:
+        """Return the most recently finalized recording."""
+
+        if self._latest_index is None:
+            raise RuntimeError("No recordings available")
+
+        path = self._path_for_index(self._latest_index, "wav")
+        if not path.exists():
+            raise RuntimeError("Latest recording file is missing")
+        return path
+
+    def transcript_path_for(self, audio_path: Path) -> Path:
+        """Return the transcript path corresponding to *audio_path*."""
+
+        return audio_path.with_suffix(".txt")
+
+
+recording_manager = RecordingManager(
+    config.recordings_dir, config.max_recordings
+)
 
 
 @app.post("/api/start_recording")
@@ -45,7 +123,9 @@ async def start_recording() -> dict:
 async def stop_recording() -> dict:
     """Stop capturing and save the WAV file."""
     try:
-        path = recorder.stop(AUDIO_PATH)
+        audio_path = recording_manager.prepare_audio_path()
+        path = recorder.stop(audio_path)
+        recording_manager.commit_recording()
         return {"status": "stopped", "audio_path": str(path)}
     except Exception as exc:
         console.log(f"Failed to stop recording: {exc}")
@@ -56,7 +136,9 @@ async def stop_recording() -> dict:
 async def run_pipeline() -> dict:
     """Transcribe the recording."""
     try:
-        t_path = transcribe(AUDIO_PATH, config)
+        audio_path = recording_manager.latest_audio_path()
+        transcript_path = recording_manager.transcript_path_for(audio_path)
+        t_path = transcribe(audio_path, config, transcript_path=transcript_path)
         return {"transcript_path": str(t_path)}
     except Exception as exc:
         console.log(f"Pipeline failed: {exc}")
@@ -71,7 +153,8 @@ async def transcribe_file(file: UploadFile = File(...)) -> dict:
         upload_path = config.recordings_dir / file.filename
         with upload_path.open("wb") as f:
             shutil.copyfileobj(file.file, f)
-        t_path = transcribe(upload_path, config)
+        transcript_path = recording_manager.transcript_path_for(upload_path)
+        t_path = transcribe(upload_path, config, transcript_path=transcript_path)
         return {"transcript_path": str(t_path)}
     except Exception as exc:
         console.log(f"File transcription failed: {exc}")


### PR DESCRIPTION
## Summary
- add configuration support for limiting the number of stored recordings
- implement a recording manager that rotates audio files and transcripts across 10 slots
- allow the transcription pipeline to write to caller-provided transcript paths for recordings and uploads

## Testing
- python -m compileall backend/src

------
https://chatgpt.com/codex/tasks/task_e_68caf81eea4883338bd96b666d06cb71